### PR TITLE
Reversi logicsの部分をBoardに切り出した

### DIFF
--- a/Reversi.xcodeproj/project.pbxproj
+++ b/Reversi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		503FF3FA2453123900D944A8 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503FF3F92453123900D944A8 /* Board.swift */; };
 		D636B39F23D35043007F370F /* DiskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636B39E23D35043007F370F /* DiskView.swift */; };
 		D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB323A9FE4500396732 /* AppDelegate.swift */; };
 		D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D642BDB523A9FE4500396732 /* SceneDelegate.swift */; };
@@ -31,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		503FF3F92453123900D944A8 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		D636B39E23D35043007F370F /* DiskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskView.swift; sourceTree = "<group>"; };
 		D642BDB023A9FE4500396732 /* Reversi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reversi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D642BDB323A9FE4500396732 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				D642BDB323A9FE4500396732 /* AppDelegate.swift */,
 				D642BDB523A9FE4500396732 /* SceneDelegate.swift */,
 				D642BDB723A9FE4500396732 /* ViewController.swift */,
+				503FF3F92453123900D944A8 /* Board.swift */,
 				D642BDB923A9FE4500396732 /* Main.storyboard */,
 				D642BDBC23A9FE4700396732 /* Assets.xcassets */,
 				D642BDBE23A9FE4700396732 /* LaunchScreen.storyboard */,
@@ -234,6 +237,7 @@
 				D642BDB823A9FE4500396732 /* ViewController.swift in Sources */,
 				D642BDDC23AA137C00396732 /* BoardView.swift in Sources */,
 				D642BDB423A9FE4500396732 /* AppDelegate.swift in Sources */,
+				503FF3FA2453123900D944A8 /* Board.swift in Sources */,
 				D642BDB623A9FE4500396732 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Reversi/Board.swift
+++ b/Reversi/Board.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+protocol Board {
+    /// 盤の幅（ `8` ）を表します。
+    var width: Int { get }
+    
+    /// 盤の高さ（ `8` ）を返します。
+    var height: Int { get }
+    
+    /// 盤のセルの `x` の範囲（ `0 ..< 8` ）を返します。
+    var xRange: Range<Int> { get }
+    
+    /// 盤のセルの `y` の範囲（ `0 ..< 8` ）を返します。
+    var yRange: Range<Int> { get }
+
+    /// 盤をゲーム開始時に状態に戻します。このメソッドはアニメーションを伴いません。
+    func reset()
+    
+    /// `x`, `y` で指定されたセルの状態を返します。
+    /// セルにディスクが置かれていない場合、 `nil` が返されます。
+    /// - Parameter x: セルの列です。
+    /// - Parameter y: セルの行です。
+    /// - Returns: セルにディスクが置かれている場合はそのディスクの値を、置かれていない場合は `nil` を返します。
+    func diskAt(x: Int, y: Int) -> Disk?
+
+    /// `x`, `y` で指定されたセルの状態を、与えられた `disk` に変更します。
+    /// `animated` が `true` の場合、アニメーションが実行されます。
+    /// アニメーションの完了通知は `completion` ハンドラーで受け取ることができます。
+    /// - Parameter disk: セルに設定される新しい状態です。 `nil` はディスクが置かれていない状態を表します。
+    /// - Parameter x: セルの列です。
+    /// - Parameter y: セルの行です。
+    /// - Parameter animated: セルの状態変更を表すアニメーションを表示するかどうかを指定します。
+    /// - Parameter completion: アニメーションの完了通知を受け取るハンドラーです。
+    ///     `animated` に `false` が指定された場合は状態が変更された後で即座に同期的に呼び出されます。
+    ///     ハンドラーが受け取る `Bool` 値は、 `UIView.animate()`  等に準じます。
+    func setDisk(_ disk: Disk?, atX x: Int, y: Int, animated: Bool, completion: ((Bool) -> Void)?)
+}
+
+extension Board {
+    /// `side` で指定された色のディスクが盤上に置かれている枚数を返します。
+    /// - Parameter side: 数えるディスクの色です。
+    /// - Returns: `side` で指定された色のディスクの、盤上の枚数です。
+    func countDisks(of side: Disk) -> Int {
+        var count = 0
+        
+        for y in yRange {
+            for x in xRange {
+                if diskAt(x: x, y: y) == side {
+                    count +=  1
+                }
+            }
+        }
+        
+        return count
+    }
+    
+    /// 盤上に置かれたディスクの枚数が多い方の色を返します。
+    /// 引き分けの場合は `nil` が返されます。
+    /// - Returns: 盤上に置かれたディスクの枚数が多い方の色です。引き分けの場合は `nil` を返します。
+    func sideWithMoreDisks() -> Disk? {
+        let darkCount = countDisks(of: .dark)
+        let lightCount = countDisks(of: .light)
+        if darkCount == lightCount {
+            return nil
+        } else {
+            return darkCount > lightCount ? .dark : .light
+        }
+    }
+    
+    // 一時的に private 外しておく。あとで考える。
+    /* private */ func flippedDiskCoordinatesByPlacingDisk(_ disk: Disk, atX x: Int, y: Int) -> [(Int, Int)] {
+        let directions = [
+            (x: -1, y: -1),
+            (x:  0, y: -1),
+            (x:  1, y: -1),
+            (x:  1, y:  0),
+            (x:  1, y:  1),
+            (x:  0, y:  1),
+            (x: -1, y:  0),
+            (x: -1, y:  1),
+        ]
+        
+        guard diskAt(x: x, y: y) == nil else {
+            return []
+        }
+        
+        var diskCoordinates: [(Int, Int)] = []
+        
+        for direction in directions {
+            var x = x
+            var y = y
+            
+            var diskCoordinatesInLine: [(Int, Int)] = []
+            flipping: while true {
+                x += direction.x
+                y += direction.y
+                
+                switch (disk, diskAt(x: x, y: y)) { // Uses tuples to make patterns exhaustive
+                case (.dark, .some(.dark)), (.light, .some(.light)):
+                    diskCoordinates.append(contentsOf: diskCoordinatesInLine)
+                    break flipping
+                case (.dark, .some(.light)), (.light, .some(.dark)):
+                    diskCoordinatesInLine.append((x, y))
+                case (_, .none):
+                    break flipping
+                }
+            }
+        }
+        
+        return diskCoordinates
+    }
+    
+    /// `x`, `y` で指定されたセルに、 `disk` が置けるかを調べます。
+    /// ディスクを置くためには、少なくとも 1 枚のディスクをひっくり返せる必要があります。
+    /// - Parameter x: セルの列です。
+    /// - Parameter y: セルの行です。
+    /// - Returns: 指定されたセルに `disk` を置ける場合は `true` を、置けない場合は `false` を返します。
+    func canPlaceDisk(_ disk: Disk, atX x: Int, y: Int) -> Bool {
+        !flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y).isEmpty
+    }
+    
+    /// `side` で指定された色のディスクを置ける盤上のセルの座標をすべて返します。
+    /// - Returns: `side` で指定された色のディスクを置ける盤上のすべてのセルの座標の配列です。
+    func validMoves(for side: Disk) -> [(x: Int, y: Int)] {
+        var coordinates: [(Int, Int)] = []
+        
+        for y in yRange {
+            for x in xRange {
+                if canPlaceDisk(side, atX: x, y: y) {
+                    coordinates.append((x, y))
+                }
+            }
+        }
+        
+        return coordinates
+    }
+}

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -71,7 +71,7 @@ extension ViewController {
             cleanUp = {}
         }
         do {
-            try placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { isFinished in
+            try boardView.placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { isFinished in
                 cleanUp()
                 completion?(isFinished)
             }
@@ -79,67 +79,7 @@ extension ViewController {
             cleanUp()
             throw error
         }
-    }
-    
-    /// `x`, `y` で指定されたセルに `disk` を置きます。
-    /// - Parameter x: セルの列です。
-    /// - Parameter y: セルの行です。
-    /// - Parameter isAnimated: ディスクを置いたりひっくり返したりするアニメーションを表示するかどうかを指定します。
-    /// - Parameter animationCanceller: アニメーションの実行をキャンセルするためのもの
-    /// - Parameter completion: アニメーション完了時に実行されるクロージャです。
-    ///     このクロージャは値を返さず、アニメーションが完了したかを示す真偽値を受け取ります。
-    ///     もし `animated` が `false` の場合、このクロージャは次の run loop サイクルの初めに実行されます。
-    /// - Throws: もし `disk` を `x`, `y` で指定されるセルに置けない場合、 `DiskPlacementError` を `throw` します。
-    func placeDisk(_ disk: Disk, atX x: Int, y: Int, animated isAnimated: Bool, animationCanceller: Canceller?, completion: ((Bool) -> Void)? = nil) throws {
-        let diskCoordinates = boardView.flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y)
-        if diskCoordinates.isEmpty {
-            throw DiskPlacementError(disk: disk, x: x, y: y)
-        }
-        
-        if isAnimated {
-            let canceller = animationCanceller ?? Canceller(nil)
-            animateSettingDisks(at: [(x, y)] + diskCoordinates, to: disk, animationCanceller: canceller) { isFinished in
-                if canceller.isCancelled { return }
-
-                completion?(isFinished)
-            }
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.boardView.setDisk(disk, atX: x, y: y, animated: false)
-                for (x, y) in diskCoordinates {
-                    self.boardView.setDisk(disk, atX: x, y: y, animated: false)
-                }
-                completion?(true)
-            }
-        }
-    }
-    
-    /// `coordinates` で指定されたセルに、アニメーションしながら順番に `disk` を置く。
-    /// `coordinates` から先頭の座標を取得してそのセルに `disk` を置き、
-    /// 残りの座標についてこのメソッドを再帰呼び出しすることで処理が行われる。
-    /// すべてのセルに `disk` が置けたら `completion` ハンドラーが呼び出される。
-    private func animateSettingDisks<C: Collection>(at coordinates: C, to disk: Disk, animationCanceller: Canceller, completion: @escaping (Bool) -> Void)
-        where C.Element == (Int, Int)
-    {
-        guard let (x, y) = coordinates.first else {
-            completion(true)
-            return
-        }
-        
-        boardView.setDisk(disk, atX: x, y: y, animated: true) { [weak self] isFinished in
-            guard let self = self else { return }
-            if animationCanceller.isCancelled { return }
-            if isFinished {
-                self.animateSettingDisks(at: coordinates.dropFirst(), to: disk, animationCanceller: animationCanceller, completion: completion)
-            } else {
-                for (x, y) in coordinates {
-                    self.boardView.setDisk(disk, atX: x, y: y, animated: false)
-                }
-                completion(false)
-            }
-        }
-    }
+    }    
 }
 
 // MARK: Game management

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -78,8 +78,6 @@ extension ViewController {
                 cleanUp()
 
                 completion?(isFinished)
-                try? self.saveGame()
-                self.updateCountLabels()
             }
         } else {
             DispatchQueue.main.async { [weak self] in
@@ -89,8 +87,6 @@ extension ViewController {
                     self.boardView.setDisk(disk, atX: x, y: y, animated: false)
                 }
                 completion?(true)
-                try? self.saveGame()
-                self.updateCountLabels()
             }
         }
     }
@@ -204,7 +200,10 @@ extension ViewController {
             cleanUp()
             
             try! self.placeDisk(turn, atX: x, y: y, animated: true) { [weak self] _ in
-                self?.nextTurn()
+                guard let self = self else { return }
+                self.nextTurn()
+                try? self.saveGame()
+                self.updateCountLabels()
             }
         }
         
@@ -299,7 +298,10 @@ extension ViewController: BoardViewDelegate {
         guard case .manual = Player(rawValue: playerControls[turn.index].selectedSegmentIndex)! else { return }
         // try? because doing nothing when an error occurs
         try? placeDisk(turn, atX: x, y: y, animated: true) { [weak self] _ in
-            self?.nextTurn()
+            guard let self = self else { return }
+            self.nextTurn()
+            try? self.saveGame()
+            self.updateCountLabels()
         }
     }
 }

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -52,103 +52,6 @@ class ViewController: UIViewController {
 // MARK: Reversi logics
 
 extension ViewController {
-    /// `side` で指定された色のディスクが盤上に置かれている枚数を返します。
-    /// - Parameter side: 数えるディスクの色です。
-    /// - Returns: `side` で指定された色のディスクの、盤上の枚数です。
-    func countDisks(of side: Disk) -> Int {
-        var count = 0
-        
-        for y in boardView.yRange {
-            for x in boardView.xRange {
-                if boardView.diskAt(x: x, y: y) == side {
-                    count +=  1
-                }
-            }
-        }
-        
-        return count
-    }
-    
-    /// 盤上に置かれたディスクの枚数が多い方の色を返します。
-    /// 引き分けの場合は `nil` が返されます。
-    /// - Returns: 盤上に置かれたディスクの枚数が多い方の色です。引き分けの場合は `nil` を返します。
-    func sideWithMoreDisks() -> Disk? {
-        let darkCount = countDisks(of: .dark)
-        let lightCount = countDisks(of: .light)
-        if darkCount == lightCount {
-            return nil
-        } else {
-            return darkCount > lightCount ? .dark : .light
-        }
-    }
-    
-    private func flippedDiskCoordinatesByPlacingDisk(_ disk: Disk, atX x: Int, y: Int) -> [(Int, Int)] {
-        let directions = [
-            (x: -1, y: -1),
-            (x:  0, y: -1),
-            (x:  1, y: -1),
-            (x:  1, y:  0),
-            (x:  1, y:  1),
-            (x:  0, y:  1),
-            (x: -1, y:  0),
-            (x: -1, y:  1),
-        ]
-        
-        guard boardView.diskAt(x: x, y: y) == nil else {
-            return []
-        }
-        
-        var diskCoordinates: [(Int, Int)] = []
-        
-        for direction in directions {
-            var x = x
-            var y = y
-            
-            var diskCoordinatesInLine: [(Int, Int)] = []
-            flipping: while true {
-                x += direction.x
-                y += direction.y
-                
-                switch (disk, boardView.diskAt(x: x, y: y)) { // Uses tuples to make patterns exhaustive
-                case (.dark, .some(.dark)), (.light, .some(.light)):
-                    diskCoordinates.append(contentsOf: diskCoordinatesInLine)
-                    break flipping
-                case (.dark, .some(.light)), (.light, .some(.dark)):
-                    diskCoordinatesInLine.append((x, y))
-                case (_, .none):
-                    break flipping
-                }
-            }
-        }
-        
-        return diskCoordinates
-    }
-    
-    /// `x`, `y` で指定されたセルに、 `disk` が置けるかを調べます。
-    /// ディスクを置くためには、少なくとも 1 枚のディスクをひっくり返せる必要があります。
-    /// - Parameter x: セルの列です。
-    /// - Parameter y: セルの行です。
-    /// - Returns: 指定されたセルに `disk` を置ける場合は `true` を、置けない場合は `false` を返します。
-    func canPlaceDisk(_ disk: Disk, atX x: Int, y: Int) -> Bool {
-        !flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y).isEmpty
-    }
-    
-    /// `side` で指定された色のディスクを置ける盤上のセルの座標をすべて返します。
-    /// - Returns: `side` で指定された色のディスクを置ける盤上のすべてのセルの座標の配列です。
-    func validMoves(for side: Disk) -> [(x: Int, y: Int)] {
-        var coordinates: [(Int, Int)] = []
-        
-        for y in boardView.yRange {
-            for x in boardView.xRange {
-                if canPlaceDisk(side, atX: x, y: y) {
-                    coordinates.append((x, y))
-                }
-            }
-        }
-        
-        return coordinates
-    }
-
     /// `x`, `y` で指定されたセルに `disk` を置きます。
     /// - Parameter x: セルの列です。
     /// - Parameter y: セルの行です。
@@ -158,7 +61,7 @@ extension ViewController {
     ///     もし `animated` が `false` の場合、このクロージャは次の run loop サイクルの初めに実行されます。
     /// - Throws: もし `disk` を `x`, `y` で指定されるセルに置けない場合、 `DiskPlacementError` を `throw` します。
     func placeDisk(_ disk: Disk, atX x: Int, y: Int, animated isAnimated: Bool, completion: ((Bool) -> Void)? = nil) throws {
-        let diskCoordinates = flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y)
+        let diskCoordinates = boardView.flippedDiskCoordinatesByPlacingDisk(disk, atX: x, y: y)
         if diskCoordinates.isEmpty {
             throw DiskPlacementError(disk: disk, x: x, y: y)
         }
@@ -257,8 +160,8 @@ extension ViewController {
 
         turn.flip()
         
-        if validMoves(for: turn).isEmpty {
-            if validMoves(for: turn.flipped).isEmpty {
+        if boardView.validMoves(for: turn).isEmpty {
+            if boardView.validMoves(for: turn.flipped).isEmpty {
                 self.turn = nil
                 updateMessageViews()
             } else {
@@ -285,7 +188,7 @@ extension ViewController {
     /// "Computer" が選択されている場合のプレイヤーの行動を決定します。
     func playTurnOfComputer() {
         guard let turn = self.turn else { preconditionFailure() }
-        let (x, y) = validMoves(for: turn).randomElement()!
+        let (x, y) = boardView.validMoves(for: turn).randomElement()!
 
         playerActivityIndicators[turn.index].startAnimating()
         
@@ -315,7 +218,7 @@ extension ViewController {
     /// 各プレイヤーの獲得したディスクの枚数を表示します。
     func updateCountLabels() {
         for side in Disk.sides {
-            countLabels[side.index].text = "\(countDisks(of: side))"
+            countLabels[side.index].text = "\(boardView.countDisks(of: side))"
         }
     }
     
@@ -327,7 +230,7 @@ extension ViewController {
             messageDiskView.disk = side
             messageLabel.text = "'s turn"
         case .none:
-            if let winner = self.sideWithMoreDisks() {
+            if let winner = boardView.sideWithMoreDisks() {
                 messageDiskSizeConstraint.constant = messageDiskSize
                 messageDiskView.disk = winner
                 messageLabel.text = " won"
@@ -570,4 +473,7 @@ extension Optional where Wrapped == Disk {
             return "-"
         }
     }
+}
+
+extension BoardView: Board {
 }

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -70,9 +70,14 @@ extension ViewController {
         } else {
             cleanUp = {}
         }
-        try placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { isFinished in
+        do {
+            try placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { isFinished in
+                cleanUp()
+                completion?(isFinished)
+            }
+        } catch let error {
             cleanUp()
-            completion?(isFinished)
+            throw error
         }
     }
     

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -71,9 +71,12 @@ extension ViewController {
             cleanUp = {}
         }
         do {
-            try boardView.placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { isFinished in
+            try boardView.placeDisk(disk, atX: x, y: y, animated: isAnimated, animationCanceller: animationCanceller) { [weak self] isFinished in
+                guard let self = self else { return }
                 cleanUp()
                 completion?(isFinished)
+                try? self.saveGame()
+                self.updateCountLabels()
             }
         } catch let error {
             cleanUp()
@@ -163,10 +166,7 @@ extension ViewController {
             cleanUp()
             
             try! self.placeDisk(turn, atX: x, y: y, animated: true) { [weak self] _ in
-                guard let self = self else { return }
-                self.nextTurn()
-                try? self.saveGame()
-                self.updateCountLabels()
+                self?.nextTurn()
             }
         }
         
@@ -261,10 +261,7 @@ extension ViewController: BoardViewDelegate {
         guard case .manual = Player(rawValue: playerControls[turn.index].selectedSegmentIndex)! else { return }
         // try? because doing nothing when an error occurs
         try? placeDisk(turn, atX: x, y: y, animated: true) { [weak self] _ in
-            guard let self = self else { return }
-            self.nextTurn()
-            try? self.saveGame()
-            self.updateCountLabels()
+            self?.nextTurn()
         }
     }
 }

--- a/Reversi/ViewController.swift
+++ b/Reversi/ViewController.swift
@@ -98,9 +98,7 @@ extension ViewController {
         
         if isAnimated {
             let canceller = animationCanceller ?? Canceller(nil)
-            animateSettingDisks(at: [(x, y)] + diskCoordinates, to: disk, animationCanceller: canceller) { [weak self] isFinished in
-                guard let self = self else { return }
-                guard let canceller = self.animationCanceller else { return }
+            animateSettingDisks(at: [(x, y)] + diskCoordinates, to: disk, animationCanceller: canceller) { isFinished in
                 if canceller.isCancelled { return }
 
                 completion?(isFinished)


### PR DESCRIPTION
ViewControllerの `// MARK: Reversi logics` のセクションに書かれていたものは、「リバーシ盤」の責務であると考え、現時点の「リバーシ盤」である `BoardView` 側へ持って行きました。
このPRでは、メソッドの実装場所が移動しただけで、新しいオブジェクトも登場しておらず、アーキテクチャについてはとくに変更ありません。

持って行ったといっても `BoardView` はそのままにしたいので、 `BoardView` のAPIを `Board` プロコトルとして切り出して、Reversi logicsはそのプロトコル拡張というかたちで実装を生やすようにしました。

なお、 `Board.placeDisk` は、アニメーション終了の非同期処理で `self` をweak参照させたいですが、 `Board` はプロトコルで値型か参照型かが判断できないので、 `where Self: AnyObject` で参照型の場合のみに実装してあります（ `Board` 全体に参照型の制約をつけてもよかったのですが、とりあえず）。

このあと、モデルとしての「リバーシ盤」と、表示用の `BoardView` を分離したいので、 `Board` そのものをプロコトルではなく「リバーシ盤」という型（おそらく値型）にしようかなと思っています。
